### PR TITLE
Update dependencies

### DIFF
--- a/gaitpy/demo/demo.py
+++ b/gaitpy/demo/demo.py
@@ -1,6 +1,6 @@
 import os
 import pandas as pd
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=UserWarning)

--- a/gaitpy/tests/test_gait.py
+++ b/gaitpy/tests/test_gait.py
@@ -1,6 +1,6 @@
 import os
 import pandas as pd
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 import numpy as np

--- a/gaitpy/tests/test_signal_features.py
+++ b/gaitpy/tests/test_signal_features.py
@@ -1,9 +1,9 @@
 import os
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 from gaitpy.signal_features import *
-from .test_gait import run_gaitpy
+from test_gait import run_gaitpy
 
 def test__signal_features():
     # Set source and destination directories

--- a/gaitpy/tests/test_util.py
+++ b/gaitpy/tests/test_util.py
@@ -1,6 +1,6 @@
 import os
 import pandas as pd
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 import numpy as np

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-pandas==0.20.3
-scipy==1.2.0
-numpy==1.13.3
-PyWavelets==0.5.2
-scikit-learn==0.21.3
-statsmodels==0.8.0
-bokeh==0.12.10
-dill==0.2.7.1
-deepdish==0.3.4
+pandas >= 0.20.3
+scipy >= 1.2.0
+numpy >= 1.13.3
+PyWavelets >= 0.5.2
+scikit-learn >= 0.21.3
+statsmodels >= 0.8.0
+bokeh >= 0.12.10
+dill >= 0.2.7.1
+deepdish >= 0.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pandas >= 0.20.3
 scipy >= 1.2.0
 numpy >= 1.13.3
 PyWavelets >= 0.5.2
-scikit-learn >= 0.21.3
+scikit-learn == 0.21.3
 statsmodels >= 0.8.0
 bokeh >= 0.12.10
 dill >= 0.2.7.1


### PR DESCRIPTION
Hi @matt002 ,

First of all, great work with the library!
I've been working a little bit with gait data and the detection worked really well.

I had an issue with the pinned dependencies similar to #23 
(tried to run gaitpy on Google Cloud Platform \ AI Notebooks where the default python env = 3.7 but couldn't get it to work).
I gave the "unpinning" a shot and it worked well with the exception of `scikit-learn`.

- Unfortunately, `scikit-learn` can't be easily unpinned, as the model underneath was done with an older version (0.18.x) that isn't compatible with new versions (0.21.3 <). I think training the model would need to be done on a newer version (no idea how much work that is, never done it myself), so I left this one pinned.
- Had to update a few imports to accommodate the pandas.testing name change but that was straightforward.
- All other dependencies I think can be non-restrictive, I didn't have any issues/conflicts with them.

Altogether, I'd hope this minor update might help someone who has a non-sandbox environment, it did help me with GCP's python 3.7 env.

Let me know your thoughts; any questions, feedback etc. is very welcome.